### PR TITLE
add classifiers to package setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,14 @@ setup(
     url='https://github.com/philipbl/python-persistent-queue',
     description='A persistent queue. It is optimized for peeking at values and'
                 ' then deleting them off to top of the queue.',
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Development Status :: 5 - Production/Stable",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
 )


### PR DESCRIPTION
A good list is available here:
https://pypi.python.org/pypi?%3Aaction=list_classifiers

I only added the most essential ones, feel free to extend the list further.

I'm assuming this package is python3-only, since this is the only one tested on Travis.
Actually testing it locally with python2.7 fails with a syntax error.