### PR TITLE
Switch to msgpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ if success:
 
 ```
 
-By default, `pickle` is used to serialize objects. This can be changed depending on your needs by setting the `dumps` and `loads` options (see Parameters). [dill](http://trac.mystic.cacr.caltech.edu/project/pathos/wiki/dill.html) and [BSON](https://github.com/py-bson/bson) have been tested (see tests as an example).
+By default, `pickle` is used to serialize objects. This can be changed depending on your needs by setting the `dumps` and `loads` options (see Parameters). [dill](http://trac.mystic.cacr.caltech.edu/project/pathos/wiki/dill.html) and [msgpack](https://github.com/msgpack/msgpack-python) have been tested (see tests as an example).
 
 When items are popped or deleted, the data isn't actually deleted. Instead a pointer is moved to the place in the file with valid data. As a result, the file will continue to grow even if items are removed. `persistent_queue.flush()` reclaims this space. **You must call `flush` as you see fit!**
 

--- a/tests/test_persistent_queue.py
+++ b/tests/test_persistent_queue.py
@@ -368,22 +368,22 @@ class TestPersistentQueueWithDill(TestPersistentQueue):
                                      dumps=dill.dumps)
 
 
-class TestPersistentQueueWithBson:
+class TestPersistentQueueWithMsgpack:
     def setup_method(self):
-        import bson
+        import msgpack
 
         random = str(uuid.uuid4()).replace('-', '')
         filename = '{}_{}'.format(self.__class__.__name__, random)
         self.queue = PersistentQueue(filename,
-                                     loads=bson.loads,
-                                     dumps=bson.dumps)
+                                     loads=msgpack.unpackb,
+                                     dumps=msgpack.packb)
 
     def teardown_method(self):
         if os.path.isfile(self.queue.filename):
             os.remove(self.queue.filename)
 
     def test_big_file_1(self):
-        data = {"a": list(range(500))}
+        data = {b"a": list(range(500))}
 
         for i in range(1000):
             self.queue.put(data)
@@ -397,7 +397,7 @@ class TestPersistentQueueWithBson:
         assert len(self.queue) == 5
 
     def test_big_file_2(self):
-        data = {"a": list(range(500))}
+        data = {b"a": list(range(500))}
 
         for i in range(1000):
             self.queue.put(data)

--- a/tests/test_persistent_queue.py
+++ b/tests/test_persistent_queue.py
@@ -78,7 +78,7 @@ class TestPersistentQueue:
         self.queue.put([10, 15, 20])
         assert self.queue.peek(items=4) == [5, 10, 15, 20]
 
-        data = {"a": 1, "b": 2, "c": [1, 2, 3]}
+        data = {b'a': 1, b'b': 2, b'c': [1, 2, 3]}
         self.queue.put(data)
         assert self.queue.peek(items=5) == [5, 10, 15, 20, data]
 
@@ -87,36 +87,36 @@ class TestPersistentQueue:
 
         self.queue.maxsize = 4
         with pytest.raises(queue.Full):
-            self.queue.put('full', timeout=1)
+            self.queue.put(b'full', timeout=1)
 
         with pytest.raises(queue.Full):
-            self.queue.put('full', block=False)
+            self.queue.put(b'full', block=False)
 
     def test_get(self):
-        self.queue.put('a')
-        self.queue.put('b')
+        self.queue.put(b'a')
+        self.queue.put(b'b')
         assert len(self.queue) == 2
 
-        assert self.queue.get() == 'a'
+        assert self.queue.get() == b'a'
         assert len(self.queue) == 1
 
-        assert self.queue.get(items=1) == 'b'
+        assert self.queue.get(items=1) == b'b'
         assert len(self.queue) == 0
 
-        self.queue.put('a')
-        self.queue.put('b')
-        self.queue.put('c')
-        self.queue.put('d')
+        self.queue.put(b'a')
+        self.queue.put(b'b')
+        self.queue.put(b'c')
+        self.queue.put(b'd')
         assert len(self.queue) == 4
 
-        assert self.queue.get(items=3) == ['a', 'b', 'c']
+        assert self.queue.get(items=3) == [b'a', b'b', b'c']
         assert len(self.queue) == 1
 
         with pytest.raises(queue.Empty):
-            assert self.queue.get(block=False, items=100) == ['d']
+            assert self.queue.get(block=False, items=100) == [b'd']
         assert len(self.queue) == 1
 
-        self.queue.put('d')
+        self.queue.put(b'd')
         assert self.queue.get(items=0) == []
         assert len(self.queue) == 2
 
@@ -153,14 +153,14 @@ class TestPersistentQueue:
     def test_peek(self):
         self.queue.put(1)
         self.queue.put(2)
-        self.queue.put("test")
+        self.queue.put(b'test')
 
         assert self.queue.peek() == 1
         assert self.queue.peek(items=1) == 1
         assert self.queue.peek(items=2) == [1, 2]
-        assert self.queue.peek(items=3) == [1, 2, "test"]
+        assert self.queue.peek(items=3) == [1, 2, b'test']
 
-        assert self.queue.peek(items=100) == [1, 2, "test"]
+        assert self.queue.peek(items=100) == [1, 2, b'test']
 
         self.queue.clear()
 
@@ -263,7 +263,7 @@ class TestPersistentQueue:
         self.queue.delete(100)
 
     def test_big_file_1(self):
-        data = {"a": list(range(500))}
+        data = {b'a': list(range(500))}
 
         for i in range(1000):
             self.queue.put(data)
@@ -277,7 +277,7 @@ class TestPersistentQueue:
         assert len(self.queue) == 5
 
     def test_big_file_2(self):
-        data = {"a": list(range(500))}
+        data = {b'a': list(range(500))}
 
         for i in range(1000):
             self.queue.put(data)
@@ -293,17 +293,17 @@ class TestPersistentQueue:
         self.queue.put(1)
         self.queue.put(2)
         self.queue.put(3)
-        self.queue.put(['a', 'b', 'c'])
+        self.queue.put([b'a', b'b', b'c'])
 
         assert self.queue.peek() == 1
-        assert self.queue.peek(items=4) == [1, 2, 3, 'a']
+        assert self.queue.peek(items=4) == [1, 2, 3, b'a']
         assert len(self.queue) == 6
 
-        self.queue.put('foobar')
+        self.queue.put(b'foobar')
 
         assert self.queue.get() == 1
         assert len(self.queue) == 6
-        assert self.queue.get(items=6) == [2, 3, 'a', 'b', 'c', 'foobar']
+        assert self.queue.get(items=6) == [2, 3, b'a', b'b', b'c', b'foobar']
 
     def test_threads(self):
         def random_stuff():
@@ -322,7 +322,7 @@ class TestPersistentQueue:
                         pass
                 else:
                     for i in range(random_number % 10):
-                        self.queue.put({"test": [1, 2, 3], "foo": "bar", "1": random_number})
+                        self.queue.put({'test': [1, 2, 3], 'foo': 'bar', '1': random_number})
 
         threads = [threading.Thread(target=random_stuff) for _ in range(10)]
 
@@ -368,7 +368,7 @@ class TestPersistentQueueWithDill(TestPersistentQueue):
                                      dumps=dill.dumps)
 
 
-class TestPersistentQueueWithMsgpack:
+class TestPersistentQueueWithMsgpack(TestPersistentQueue):
     def setup_method(self):
         import msgpack
 
@@ -377,34 +377,3 @@ class TestPersistentQueueWithMsgpack:
         self.queue = PersistentQueue(filename,
                                      loads=msgpack.unpackb,
                                      dumps=msgpack.packb)
-
-    def teardown_method(self):
-        if os.path.isfile(self.queue.filename):
-            os.remove(self.queue.filename)
-
-    def test_big_file_1(self):
-        data = {b"a": list(range(500))}
-
-        for i in range(1000):
-            self.queue.put(data)
-
-        assert len(self.queue) == 1000
-
-        for i in range(995):
-            assert self.queue.get() == data
-            self.queue.flush()
-
-        assert len(self.queue) == 5
-
-    def test_big_file_2(self):
-        data = {b"a": list(range(500))}
-
-        for i in range(1000):
-            self.queue.put(data)
-
-        assert self.queue.get(items=995) == [data for i in range(995)]
-        self.queue.flush()
-        assert len(self.queue) == 5
-
-        import time
-        time.sleep(1)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ toxworkdir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 deps =
-  bson==0.4.3
+  msgpack-python==0.4.8
   dill==0.2.5
   coveralls>=1.1,<2
   pytest>=3.0.4,<4


### PR DESCRIPTION
Switch from using bson to msgpack. Fixes #14.

~~Unfortunately, not all the tests can be run msgpack without changing many of the tests.~~ When msgpack returns a string, it returns the byte representation of that string (`b'foobar'` compared to `'foobar'`). However, msgpack seems better than bson because it can handle data types other than dicts. 

On a personal note, I actually use msgpack with persistent-queue in some of my code, so I would like to see msgpack tested.