### PR TITLE
Fix putting None in queue

### DIFF
--- a/tests/test_persistent_queue.py
+++ b/tests/test_persistent_queue.py
@@ -276,6 +276,23 @@ class TestPersistentQueue:
         assert len(self.queue) == 1
         assert self.queue.get() == None
 
+    def test_return_types(self):
+        self.queue.put([1, 2, 3, 4])
+
+        assert isinstance(self.queue.get(), int)
+        assert isinstance(self.queue.get(items=1), int)
+        assert isinstance(self.queue.get(items=2), list)
+
+        with pytest.raises(queue.Empty):
+            self.queue.get(block=False)
+
+        self.queue.put([5, 6])
+        with pytest.raises(queue.Empty):
+            self.queue.get(items=100, block=False)
+
+        assert isinstance(self.queue.peek(), int)
+        assert isinstance(self.queue.peek(items=2), list)
+
     def test_big_file_1(self):
         data = {b'a': list(range(500))}
 

--- a/tests/test_persistent_queue.py
+++ b/tests/test_persistent_queue.py
@@ -262,6 +262,20 @@ class TestPersistentQueue:
         self.queue.delete()
         self.queue.delete(100)
 
+    def test_push_none(self):
+        self.queue.put(1)
+        self.queue.put(None)
+        self.queue.put(None)
+
+        assert len(self.queue) == 3
+        assert self.queue.get() == 1
+
+        assert len(self.queue) == 2
+        assert self.queue.get() == None
+
+        assert len(self.queue) == 1
+        assert self.queue.get() == None
+
     def test_big_file_1(self):
         data = {b'a': list(range(500))}
 

--- a/tests/test_persistent_queue.py
+++ b/tests/test_persistent_queue.py
@@ -271,26 +271,34 @@ class TestPersistentQueue:
         assert self.queue.get() == 1
 
         assert len(self.queue) == 2
-        assert self.queue.get() == None
+        assert self.queue.get() is None
 
         assert len(self.queue) == 1
-        assert self.queue.get() == None
+        assert self.queue.get() is None
 
     def test_return_types(self):
-        self.queue.put([1, 2, 3, 4])
+        assert self.queue.peek(items=0) == []
+        assert self.queue.peek(items=1) is None
+        assert self.queue.peek(items=2) == []
+        assert self.queue.peek(items=100) == []
 
-        assert isinstance(self.queue.get(), int)
-        assert isinstance(self.queue.get(items=1), int)
-        assert isinstance(self.queue.get(items=2), list)
-
+        assert self.queue.get(items=0, block=False) == []
         with pytest.raises(queue.Empty):
-            self.queue.get(block=False)
-
-        self.queue.put([5, 6])
+            self.queue.get(items=1, block=False)
+        with pytest.raises(queue.Empty):
+            self.queue.get(items=2, block=False)
         with pytest.raises(queue.Empty):
             self.queue.get(items=100, block=False)
 
-        assert isinstance(self.queue.peek(), int)
+        self.queue.put([1, 2, 3, 4, 5])
+
+        assert isinstance(self.queue.get(), int)
+        assert isinstance(self.queue.get(items=0), list)
+        assert isinstance(self.queue.get(items=1), int)
+        assert isinstance(self.queue.get(items=2), list)
+
+        assert isinstance(self.queue.peek(items=0), list)
+        assert isinstance(self.queue.peek(items=1), int)
         assert isinstance(self.queue.peek(items=2), list)
 
     def test_big_file_1(self):


### PR DESCRIPTION
Fixes #9.

Previously, there was no way of distinguishing between when a None was returned from the queue or if there is no data in the queue. As a result, the queue size would not get updated when it should have.